### PR TITLE
Added syntax for weak constraints

### DIFF
--- a/grammars/clingo.cson
+++ b/grammars/clingo.cson
@@ -33,6 +33,10 @@
     'name': 'keyword.operator.clingo'
   },
   {
+    'match': ':~'
+    'name': 'keyword.operator.clingo'
+  },
+  {
     'match': '\\s\\:\\s'
     'name': 'keyword.operator.clingo'
   },


### PR DESCRIPTION
The `:~` operator was not highlighted.